### PR TITLE
Point to the correct github repository

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'adornis:typescript',
   version: '0.9.3',
   summary: 'TypeScript for Meteor',
-  git: 'https://github.com/barbatus/typescript',
+  git: 'https://github.com/Adornis/typescript',
   documentation: 'README.md',
 });
 


### PR DESCRIPTION
https://atmospherejs.com/adornis/typescript-compiler points to the barbatus repository, which is confusing